### PR TITLE
Feature/delete saved posters

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -126,6 +126,7 @@ showMain.addEventListener('click', showMainPoster);
 backToMain.addEventListener('click', showMainPoster);
 makePoster.addEventListener('click', showMyPoster);
 savePoster.addEventListener('click', storeSavePoster);
+savedPostersGrid.addEventListener('dbclick', removeSavedPoster);
 
 function getRandomIndex(array) {
   return Math.floor(Math.random() * array.length);
@@ -200,3 +201,5 @@ function showSavedPosterGrid() {
     }
   }
 }
+
+function

--- a/src/main.js
+++ b/src/main.js
@@ -126,7 +126,7 @@ showMain.addEventListener('click', showMainPoster);
 backToMain.addEventListener('click', showMainPoster);
 makePoster.addEventListener('click', showMyPoster);
 savePoster.addEventListener('click', storeSavePoster);
-savedPostersGrid.addEventListener('dbclick', removeSavedPoster);
+savedPostersGrid.addEventListener('dblclick', removeSavedPoster);
 
 function getRandomIndex(array) {
   return Math.floor(Math.random() * array.length);
@@ -175,14 +175,14 @@ function storeSavePoster() {
   images.push(inputImage.value);
   titles.push(inputTitle.value);
   quotes.push(inputQuote.value);
-  if(deleteDuplicateSavedPosters()) {
+  if (deleteDuplicateSavedPosters()) {
     savedPosters.push(currentPoster);
   }
 }
 
 function deleteDuplicateSavedPosters() {
   for (var i = 0; i < savedPosters.length; i++) {
-    if(savedPosters[i].id == currentPoster.id) {
+    if (savedPosters[i].id == currentPoster.id) {
       return false;
     }
   }
@@ -190,7 +190,7 @@ function deleteDuplicateSavedPosters() {
 }
 
 function showSavedPosterGrid() {
-  if(savedPosters.length != 0) {
+  if (savedPosters.length != 0) {
     for (var i = 0; i < savedPosters.length; i++) {
       savedPostersGrid.insertAdjacentHTML("afterbegin", `
       <div class="mini-poster" data-id=${savedPosters[i].id}>
@@ -202,4 +202,13 @@ function showSavedPosterGrid() {
   }
 }
 
-function
+function removeSavedPoster(event) {
+    var deletePosterHTML = event.target.closest(".mini-poster");
+    for (var i = 0; i < savedPosters.length; i++) {
+      if (savedPosters[i].id == deletePosterHTML.dataset.id) {
+        savedPosters.splice(i, 1);
+        savedPostersGrid.innerHTML = "";
+        showSavedPosterGrid();
+    }
+  }
+}


### PR DESCRIPTION
# Description

_Created functionality to double click on a saved poster to remove it from the saved poster grid_

_First, I added an event listener to listen for a double click within the saved poster grid._

_Second, I added the RemoveSavedPoster handler in which I declared a variable and gave it a value of an event that is grabbing the closest mini poster to the double click. Then I created a for loop that is going through the savedPosters array and if the id is the same as the variable that I declared, then the handler will splice the first saved poster in the array. Once the saved poster has been removed then the savedPostersGrid will be displayed_

_I also fixed the syntax of the spaces after the if's in the if statements_

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?

- [ ] No
- [x] Yes

_I opened index.html and the console to see if it worked, and it did._

# Checklist:
- [x] My code has no unused/commented out code
- [x] My code has no console logs
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas